### PR TITLE
fix: including activities pictures, time and type on activityFeed

### DIFF
--- a/src/components/Activity/Activity.module.css
+++ b/src/components/Activity/Activity.module.css
@@ -12,6 +12,7 @@
   display: flex;
   align-items: center;
   margin-bottom: 8px;
+  margin-top: 25px;
 }
 
 .avatar {

--- a/src/components/Activity/Activity.module.css
+++ b/src/components/Activity/Activity.module.css
@@ -5,7 +5,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  gap: 20px;
+  gap: 10px;
 }
 
 .header {
@@ -50,11 +50,42 @@
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   width: 100%;
-  padding-bottom: 15px;
 }
 
 .cardWrapper {
   scroll-snap-align: start;
   scroll-margin-left: 20px;
   flex-shrink: 0;
+}
+
+.activityBox {
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+}
+
+.activityName {
+  display: flex;
+  flex-direction: column;
+}
+
+.activityDuration {
+  display: flex;
+  flex-direction: column;
+}
+
+.activityName span,
+.activityDuration span {
+  color: #434343;
+  font-size: var(--LABEL-SMALL);
+  font-weight: 400;
+  line-height: 150%;
+}
+
+.activityName p,
+.activityDuration p {
+  color: var(--TEXT-PRIMARY);
+  font-size: var(--TITLE);
+  font-weight: 700;
+  line-height: 150%;
 }

--- a/src/components/Activity/Activity.tsx
+++ b/src/components/Activity/Activity.tsx
@@ -17,6 +17,8 @@ type Props = {
   isUserView: boolean;
   onDeletePost?: (id: string) => void;
   showOptions: boolean;
+  categoryName: string;
+  duration: string;
 };
 
 function Activity({
@@ -30,6 +32,8 @@ function Activity({
   isUserView,
   onDeletePost,
   showOptions,
+  categoryName,
+  duration,
 }: Props) {
   return (
     <div className={style.post}>
@@ -49,6 +53,16 @@ function Activity({
           ))}
         </div>
       )}
+      <div className={style.activityBox}>
+        <div className={style.activityName}>
+          <span>Atividade</span>
+          <p>{categoryName} </p>
+        </div>
+        <div className={style.activityDuration}>
+          <span>Tempo</span>
+          <p>{duration} </p>
+        </div>
+      </div>
       <span className={style.date}>{postDate}</span>
 
       <InteractionBox

--- a/src/components/InteractionBox/InteractionBox.tsx
+++ b/src/components/InteractionBox/InteractionBox.tsx
@@ -5,7 +5,6 @@ import ChatText from '../../assets/ChatText.svg';
 import PaperPlane from '../../assets/PaperPlaneTilt.svg';
 import DotsThree from '../../assets/DotsThree.svg';
 import Trash from '../../assets/Trash.svg';
-import Pencil from '../../assets/PencilSimple.svg';
 import { useState } from 'react';
 import DeletePostModal from '../DeletePostModal/DeletePostModal';
 import { deletePost } from '@/utils/deletePost';
@@ -87,10 +86,6 @@ function InteractionBox({
             <div
               className={`${style.editPost} ${showEditPost ? style.showEditPost : ''}`}
             >
-              <div className={style.interactionItem}>
-                <img src={Pencil} alt="Editar Post" />
-                <span className={style.interactionTitle}>Editar</span>
-              </div>
               <div
                 className={style.interactionItem}
                 onClick={handleOpenDeleteModal}

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -8,6 +8,21 @@ import { useQuery } from '@tanstack/react-query';
 import { getProfile } from '../../services/requests';
 import Activity from '@/components/Activity/Activity';
 import { formatedActivityDate } from '../../utils/formatActivityDate';
+import { formatDuration } from '../../utils/formatDuration';
+
+const categoryMap: Record<number, string> = {
+  1: 'Corrida',
+  2: 'Caminhada',
+  3: 'Ciclismo',
+  4: 'Trilha',
+  5: 'Futebol',
+  6: 'Basquete',
+  7: 'Vôlei',
+  8: 'Tênis',
+  9: 'Natação',
+  10: 'Musculação',
+  11: 'Crossfit',
+};
 
 function Profile() {
   const [showActivityChart, setShowActivityChart] = useState(true);
@@ -97,6 +112,9 @@ function Profile() {
               onOpenComments={handleOpenModalComments}
               isUserView={activity.user_id === profileData.id}
               showOptions={true}
+              activityImage={activity.media}
+              categoryName={categoryMap[activity.category_id]}
+              duration={formatDuration(activity.duration)}
             />
           ))}
         </div>

--- a/src/utils/formatDuration.ts
+++ b/src/utils/formatDuration.ts
@@ -1,0 +1,9 @@
+export function formatDuration(duration: number): string {
+  const hours = Math.floor(duration / 3600);
+  const minutes = Math.floor((duration % 3600) / 60);
+
+  if (hours === 0) {
+    return `${minutes}m`;
+  }
+  return `${hours}h${minutes}m`;
+}


### PR DESCRIPTION
Olá Dani, Bom dia! 

Essa PR é referente ao  activityFeed que consta na Página Profile.
Foi feito o ajuste no cadastro da página New Activity e agora as imagens estão sendo enviadas corretamente.

Foram alterados os seguintes arquivos: 
- Activity.tsx
- Activity.module.css
- Profile.tsx

Inclusão:
- formatDuration.ts: função que pega a duração da atividade que a api retorna e transforma em horas e segundos.

Segue imagens das telas integradas: 
![image](https://github.com/user-attachments/assets/bffb18e5-7727-4bb2-9ee7-c7923d9c0b24)
![image](https://github.com/user-attachments/assets/74926ecc-687d-4a7d-a0bc-a0ba8e449d69)




