### PR TITLE
fix: insertion of padding-bottom and Loading on Pages Profile and Notifications

### DIFF
--- a/src/pages/Notifications/Notifications.module.css
+++ b/src/pages/Notifications/Notifications.module.css
@@ -1,6 +1,7 @@
 .container {
   width: 100%;
   height: 100%;
+  padding-bottom: 64px;
 }
 
 .navigation {

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -8,6 +8,7 @@ import { getProfile } from '../../services/requests';
 import Activity from '@/components/Activity/Activity';
 import { formatedActivityDate } from '../../utils/formatActivityDate';
 import { formatDuration } from '../../utils/formatDuration';
+import Loading from '@/components/Loading/Loading';
 
 const categoryMap: Record<number, string> = {
   1: 'Corrida',
@@ -28,12 +29,21 @@ import { ProfileTypes } from '@/types/profileTypes';
 function Profile() {
   const [showActivityChart, setShowActivityChart] = useState(true);
   const [openModal, setOpenModal] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const { data: profileData } = useQuery({
     queryKey: ['profileData'],
     queryFn: async () => {
-      const response = await getProfile();
-      return response;
+      try {
+        setLoading(true);
+        const response = await getProfile();
+        return response;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        throw error.response.data;
+      } finally {
+        setLoading(false);
+      }
     },
   });
 
@@ -139,11 +149,11 @@ function Profile() {
               openModal={openModal}
               handleCloseModalComments={handleCloseModalComments}
               listComments={activity.comments}
-
             />
           ))}
         </div>
       )}
+      <Loading show={loading} />
     </div>
   );
 }


### PR DESCRIPTION
Olá Dani, Boa Tarde!

Conforme solicitado, inseri o Loading nas Páginas Profile e Notifications, que são as que mais são demoradas para carregar.
Também inseri padding-bottom na página, de forma que as notificações fiquem visíveis.

Abaixo prints: 
Páginas carregando: 
![image](https://github.com/user-attachments/assets/e0783407-e1de-4081-a36b-f95388eb6b7e)
![image](https://github.com/user-attachments/assets/affbe52c-417d-4bb7-9e5d-e86ebd149a15)

Páginas carregadas:
![image](https://github.com/user-attachments/assets/85f2525b-c7ec-474d-86e9-442bdd1c450d)
![image](https://github.com/user-attachments/assets/232f1f21-0944-4c0e-9f46-dd00c52d836c)



